### PR TITLE
feat(frontend): make territory background stick to islands when panning

### DIFF
--- a/backend/internal/mock/data/territories/territory1.json
+++ b/backend/internal/mock/data/territories/territory1.json
@@ -1,7 +1,7 @@
 {
   "id": "territory1",
   "name": "جزایر اسرارآمیز",
-  "backgroundAsset": "/images/backgrounds/territory/background1.jpg",
+  "backgroundAsset": "/images/backgrounds/territory/1.jpg",
   "startIsland": "island_start",
   "islands": [
     {

--- a/backend/internal/mock/data/territories/territory2.json
+++ b/backend/internal/mock/data/territories/territory2.json
@@ -1,7 +1,7 @@
 {
   "id": "territory2",
   "name": "جزایر دور",
-  "backgroundAsset": "/images/backgrounds/territory/background1.jpg",
+  "backgroundAsset": "/images/backgrounds/territory/1.jpg",
   "startIsland": "island_thompson",
   "islands": [
     {

--- a/backend/internal/mock/data/territories/territory3.json
+++ b/backend/internal/mock/data/territories/territory3.json
@@ -1,7 +1,7 @@
 {
   "id": "territory3",
   "name": "کهکشان راه گاوی",
-  "backgroundAsset": "/images/backgrounds/territory/background2.jpg",
+  "backgroundAsset": "/images/backgrounds/territory/2.jpg",
   "startIsland": "asset_1757105018117",
   "islands": [
     {

--- a/backend/main.go
+++ b/backend/main.go
@@ -22,7 +22,13 @@ func main() {
 
 	domain.ApplyConfig(cfg)
 
-	theBot, err := bot.New(cfg.BotToken, bot.WithServerURL("https://tapi.bale.ai"))
+	botOptions := []bot.Option{bot.WithServerURL("https://tapi.bale.ai")}
+	if cfg.DevMode {
+		// In dev mode the Bale bot API is often unreachable and not needed to
+		// exercise the game locally; skip the GetMe network call on init.
+		botOptions = append(botOptions, bot.WithSkipGetMe())
+	}
+	theBot, err := bot.New(cfg.BotToken, botOptions...)
 	if err != nil {
 		log.Fatal("failed to connect to bot api: ", err)
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -24,8 +24,6 @@ func main() {
 
 	botOptions := []bot.Option{bot.WithServerURL("https://tapi.bale.ai")}
 	if cfg.DevMode {
-		// In dev mode the Bale bot API is often unreachable and not needed to
-		// exercise the game locally; skip the GetMe network call on init.
 		botOptions = append(botOptions, bot.WithSkipGetMe())
 	}
 	theBot, err := bot.New(cfg.BotToken, botOptions...)

--- a/frontend/src/components/features/map/MapView.vue
+++ b/frontend/src/components/features/map/MapView.vue
@@ -109,7 +109,7 @@
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue';
 import panzoom from 'panzoom';
 import { getPlayersLocation } from '@/services/api';
-import { APP_CONFIG } from '@/config/appConfig.js';
+import { APP_CONFIG, BACKGROUND_MODES } from '@/config/appConfig.js';
 
 const props = defineProps({
     islands: { type: Array, required: true },
@@ -121,7 +121,7 @@ const props = defineProps({
     backgroundImage: { type: String, default: '' },
 });
 
-const stickBackground = APP_CONFIG.STICK_BACKGROUND_TO_ISLANDS;
+const stickBackground = APP_CONFIG.BACKGROUND_MODE === BACKGROUND_MODES.STICK;
 
 const backgroundAspect = ref(null);
 

--- a/frontend/src/components/features/map/MapView.vue
+++ b/frontend/src/components/features/map/MapView.vue
@@ -123,9 +123,6 @@ const props = defineProps({
 
 const stickBackground = APP_CONFIG.STICK_BACKGROUND_TO_ISLANDS;
 
-// Natural aspect ratio (width / height) of the background image, once loaded.
-// We need it so the rendered rect matches the image's proportions and the image
-// neither gets cropped nor stretched.
 const backgroundAspect = ref(null);
 
 watch(
@@ -144,16 +141,8 @@ watch(
     { immediate: true }
 );
 
-// Size of the <svg> element (px). Kept reactive so the background can be sized
-// to fit the actual viewport at minimum zoom.
 const svgClientSize = ref({ width: 0, height: 0 });
 
-// When the background sticks to the islands it is rendered inside the panzoom'd
-// SVG (in the same user-space coordinates). We size the image so that at minimum
-// zoom (scale 1) the *whole* image is visible and just fits the viewport — i.e.
-// the entire artwork shows as a backdrop rather than a cropped center slice —
-// then centre it on the island cluster. Zooming in reveals detail, and
-// `constrainToBackground()` keeps the view from drifting off it.
 const backgroundRect = computed(() => {
     const parts = props.dynamicViewBox.split(/\s+/).map(Number);
     const [minX, minY, vbWidth, vbHeight] =
@@ -164,22 +153,15 @@ const backgroundRect = computed(() => {
     const centerX = minX + vbWidth / 2;
     const centerY = minY + vbHeight / 2;
 
-    // At min zoom the viewBox is fitted to the <svg> box with `meet` (uniform
-    // scale = the smaller axis ratio). The window then spans this many user
-    // units — that's the area we want the whole image to fill/fit.
     const { width: cw, height: ch } = svgClientSize.value;
     let visibleW = vbWidth;
     let visibleH = vbHeight;
     if (cw > 0 && ch > 0) {
-        const meetScale = Math.min(cw / vbWidth, ch / vbHeight); // px per unit
+        const meetScale = Math.min(cw / vbWidth, ch / vbHeight);
         visibleW = cw / meetScale;
         visibleH = ch / meetScale;
     }
 
-    // Fit the image inside the visible area preserving its aspect ratio
-    // (object-fit: contain), so the whole image is on screen at min zoom. The
-    // rect matches the image aspect exactly, so the `<image>`'s own
-    // preserveAspectRatio never adds a second round of letterboxing.
     const aspect = backgroundAspect.value || visibleW / visibleH || 1;
     let width = visibleW;
     let height = visibleW / aspect;
@@ -313,42 +295,27 @@ const wavyEdges = computed(() => {
     });
 });
 
-// Guards against re-entrancy: adjusting the pan inside the `transform` handler
-// fires another `transform` event.
 let constraining = false;
 
-// Keeps the view sitting on top of the background so the blue backdrop only
-// ever shows as thin padding. When the background is larger than the viewport
-// (zoomed in) we clamp the pan so no edge crosses into view; when it is smaller
-// than the viewport (zoomed out) we center it. The net effect is that zooming
-// out pulls the view back toward the middle of the background.
 const constrainToBackground = () => {
     if (!stickBackground || constraining || !panzoomInstance || !svgRef.value) {
         return;
     }
     const svg = svgRef.value;
 
-    // The visible map is clipped to the <svg> element's own box (it has
-    // overflow:hidden), and panzoom applies its zoom/pan as a CSS transform on
-    // that same <svg>. So the thing that must always cover the viewport is the
-    // transformed <svg> box itself; anything the <svg> box doesn't cover shows
-    // the parent's solid backdrop. We measure in screen pixels via
-    // getBoundingClientRect so this is agnostic to how panzoom transforms.
     const view = svg.parentElement.getBoundingClientRect();
     const map = svg.getBoundingClientRect();
 
-    // How far to nudge the pan (screen px) so the map covers the view; if the
-    // map is smaller than the view on an axis, center it instead.
     const adjust = (mapMin, mapSize, viewMin, viewSize) => {
         const mapMax = mapMin + mapSize;
         const viewMax = viewMin + viewSize;
         if (mapSize <= viewSize) {
             const mapCenter = mapMin + mapSize / 2;
             const viewCenter = viewMin + viewSize / 2;
-            return viewCenter - mapCenter; // center it
+            return viewCenter - mapCenter;
         }
-        if (mapMin > viewMin) return viewMin - mapMin; // gap on leading edge
-        if (mapMax < viewMax) return viewMax - mapMax; // gap on trailing edge
+        if (mapMin > viewMin) return viewMin - mapMin;
+        if (mapMax < viewMax) return viewMax - mapMax;
         return 0;
     };
 
@@ -482,8 +449,6 @@ const shipSrc = name => {
     return '/images/ships/' + ((sum % 11) + 1) + '.png';
 };
 
-// Re-apply the constraint when the background rect changes (e.g. its aspect
-// ratio resolves after the image loads, or the territory changes).
 watch(backgroundRect, () => {
     nextTick(constrainToBackground);
 });

--- a/frontend/src/components/features/map/MapView.vue
+++ b/frontend/src/components/features/map/MapView.vue
@@ -17,6 +17,17 @@
         preserveAspectRatio="xMidYMid meet"
         class="w-full h-full block cursor-grab active:cursor-grabbing"
     >
+        <image
+            v-if="stickBackground && backgroundImage"
+            :href="backgroundImage"
+            :x="backgroundRect.x"
+            :y="backgroundRect.y"
+            :width="backgroundRect.width"
+            :height="backgroundRect.height"
+            preserveAspectRatio="xMidYMid slice"
+            class="pointer-events-none"
+        />
+
         <g class="edges">
             <path
                 v-for="edge in wavyEdges"
@@ -98,6 +109,7 @@
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue';
 import panzoom from 'panzoom';
 import { getPlayersLocation } from '@/services/api';
+import { APP_CONFIG } from '@/config/appConfig.js';
 
 const props = defineProps({
     islands: { type: Array, required: true },
@@ -106,6 +118,82 @@ const props = defineProps({
     dynamicViewBox: { type: String, required: true },
     territoryId: { type: String, required: true },
     username: { type: String, required: true },
+    backgroundImage: { type: String, default: '' },
+});
+
+const stickBackground = APP_CONFIG.STICK_BACKGROUND_TO_ISLANDS;
+
+// Natural aspect ratio (width / height) of the background image, once loaded.
+// We need it so the rendered rect matches the image's proportions and the image
+// neither gets cropped nor stretched.
+const backgroundAspect = ref(null);
+
+watch(
+    () => props.backgroundImage,
+    src => {
+        backgroundAspect.value = null;
+        if (!stickBackground || !src) return;
+        const img = new Image();
+        img.onload = () => {
+            if (img.naturalHeight > 0) {
+                backgroundAspect.value = img.naturalWidth / img.naturalHeight;
+            }
+        };
+        img.src = src;
+    },
+    { immediate: true }
+);
+
+// Size of the <svg> element (px). Kept reactive so the background can be sized
+// to fit the actual viewport at minimum zoom.
+const svgClientSize = ref({ width: 0, height: 0 });
+
+// When the background sticks to the islands it is rendered inside the panzoom'd
+// SVG (in the same user-space coordinates). We size the image so that at minimum
+// zoom (scale 1) the *whole* image is visible and just fits the viewport — i.e.
+// the entire artwork shows as a backdrop rather than a cropped center slice —
+// then centre it on the island cluster. Zooming in reveals detail, and
+// `constrainToBackground()` keeps the view from drifting off it.
+const backgroundRect = computed(() => {
+    const parts = props.dynamicViewBox.split(/\s+/).map(Number);
+    const [minX, minY, vbWidth, vbHeight] =
+        parts.length === 4 && parts.every(n => Number.isFinite(n))
+            ? parts
+            : [0, 0, 1, 1];
+
+    const centerX = minX + vbWidth / 2;
+    const centerY = minY + vbHeight / 2;
+
+    // At min zoom the viewBox is fitted to the <svg> box with `meet` (uniform
+    // scale = the smaller axis ratio). The window then spans this many user
+    // units — that's the area we want the whole image to fill/fit.
+    const { width: cw, height: ch } = svgClientSize.value;
+    let visibleW = vbWidth;
+    let visibleH = vbHeight;
+    if (cw > 0 && ch > 0) {
+        const meetScale = Math.min(cw / vbWidth, ch / vbHeight); // px per unit
+        visibleW = cw / meetScale;
+        visibleH = ch / meetScale;
+    }
+
+    // Fit the image inside the visible area preserving its aspect ratio
+    // (object-fit: contain), so the whole image is on screen at min zoom. The
+    // rect matches the image aspect exactly, so the `<image>`'s own
+    // preserveAspectRatio never adds a second round of letterboxing.
+    const aspect = backgroundAspect.value || visibleW / visibleH || 1;
+    let width = visibleW;
+    let height = visibleW / aspect;
+    if (height > visibleH) {
+        height = visibleH;
+        width = visibleH * aspect;
+    }
+
+    return {
+        x: centerX - width / 2,
+        y: centerY - height / 2,
+        width,
+        height,
+    };
 });
 
 const emit = defineEmits(['nodeClick', 'mapTransformed']);
@@ -225,6 +313,56 @@ const wavyEdges = computed(() => {
     });
 });
 
+// Guards against re-entrancy: adjusting the pan inside the `transform` handler
+// fires another `transform` event.
+let constraining = false;
+
+// Keeps the view sitting on top of the background so the blue backdrop only
+// ever shows as thin padding. When the background is larger than the viewport
+// (zoomed in) we clamp the pan so no edge crosses into view; when it is smaller
+// than the viewport (zoomed out) we center it. The net effect is that zooming
+// out pulls the view back toward the middle of the background.
+const constrainToBackground = () => {
+    if (!stickBackground || constraining || !panzoomInstance || !svgRef.value) {
+        return;
+    }
+    const svg = svgRef.value;
+
+    // The visible map is clipped to the <svg> element's own box (it has
+    // overflow:hidden), and panzoom applies its zoom/pan as a CSS transform on
+    // that same <svg>. So the thing that must always cover the viewport is the
+    // transformed <svg> box itself; anything the <svg> box doesn't cover shows
+    // the parent's solid backdrop. We measure in screen pixels via
+    // getBoundingClientRect so this is agnostic to how panzoom transforms.
+    const view = svg.parentElement.getBoundingClientRect();
+    const map = svg.getBoundingClientRect();
+
+    // How far to nudge the pan (screen px) so the map covers the view; if the
+    // map is smaller than the view on an axis, center it instead.
+    const adjust = (mapMin, mapSize, viewMin, viewSize) => {
+        const mapMax = mapMin + mapSize;
+        const viewMax = viewMin + viewSize;
+        if (mapSize <= viewSize) {
+            const mapCenter = mapMin + mapSize / 2;
+            const viewCenter = viewMin + viewSize / 2;
+            return viewCenter - mapCenter; // center it
+        }
+        if (mapMin > viewMin) return viewMin - mapMin; // gap on leading edge
+        if (mapMax < viewMax) return viewMax - mapMax; // gap on trailing edge
+        return 0;
+    };
+
+    const dx = adjust(map.left, map.width, view.left, view.width);
+    const dy = adjust(map.top, map.height, view.top, view.height);
+
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) return;
+
+    const t = panzoomInstance.getTransform();
+    constraining = true;
+    panzoomInstance.moveTo(t.x + dx, t.y + dy);
+    constraining = false;
+};
+
 const initializePanzoom = () => {
     if (!svgRef.value || panzoomInstance) return;
 
@@ -265,6 +403,7 @@ const initializePanzoom = () => {
     });
 
     panzoomInstance.on('transform', () => {
+        constrainToBackground();
         const transform = panzoomInstance.getTransform();
         emit('mapTransformed', {
             x: transform.x,
@@ -343,13 +482,35 @@ const shipSrc = name => {
     return '/images/ships/' + ((sum % 11) + 1) + '.png';
 };
 
+// Re-apply the constraint when the background rect changes (e.g. its aspect
+// ratio resolves after the image loads, or the territory changes).
+watch(backgroundRect, () => {
+    nextTick(constrainToBackground);
+});
+
+let svgResizeObserver = null;
+
+const measureSvg = () => {
+    if (!svgRef.value) return;
+    svgClientSize.value = {
+        width: svgRef.value.clientWidth,
+        height: svgRef.value.clientHeight,
+    };
+};
+
 onMounted(() => {
     initializePanzoom();
     fetchOtherPlayers();
+    measureSvg();
+    if (window.ResizeObserver && svgRef.value) {
+        svgResizeObserver = new ResizeObserver(measureSvg);
+        svgResizeObserver.observe(svgRef.value);
+    }
 });
 
 onUnmounted(() => {
     if (panzoomInstance) panzoomInstance.dispose();
+    if (svgResizeObserver) svgResizeObserver.disconnect();
 });
 
 defineExpose({

--- a/frontend/src/config/appConfig.js
+++ b/frontend/src/config/appConfig.js
@@ -1,3 +1,9 @@
+export const BACKGROUND_MODES = {
+    STICK: 'stick',
+    FIXED: 'fixed',
+    STARRY: 'starry',
+};
+
 export const APP_CONFIG = {
-    STICK_BACKGROUND_TO_ISLANDS: false,
+    BACKGROUND_MODE: BACKGROUND_MODES.STARRY,
 };

--- a/frontend/src/config/appConfig.js
+++ b/frontend/src/config/appConfig.js
@@ -1,19 +1,3 @@
-// Application-level UI/behavior configuration.
-//
-// These are hardcoded build-time constants (mirroring the pattern used in
-// `src/services/api/base_url.js`); there is no `.env`/`import.meta.env` usage
-// in the frontend, so changing behavior means editing this file and rebuilding.
-
 export const APP_CONFIG = {
-    // Whether the territory map background should stick to (pan/zoom together
-    // with) the islands.
-    //
-    //   true  — the background lives inside the panzoom'd map, so when the
-    //           player drags the map the background moves with the islands.
-    //           This is the intended behavior: islands stay fixed relative to
-    //           the background instead of appearing to slide across a static
-    //           backdrop.
-    //   false — the background is rendered as a static, fixed backdrop while
-    //           the islands pan/zoom on top of it (legacy behavior).
     STICK_BACKGROUND_TO_ISLANDS: true,
 };

--- a/frontend/src/config/appConfig.js
+++ b/frontend/src/config/appConfig.js
@@ -1,3 +1,3 @@
 export const APP_CONFIG = {
-    STICK_BACKGROUND_TO_ISLANDS: true,
+    STICK_BACKGROUND_TO_ISLANDS: false,
 };

--- a/frontend/src/config/appConfig.js
+++ b/frontend/src/config/appConfig.js
@@ -1,0 +1,19 @@
+// Application-level UI/behavior configuration.
+//
+// These are hardcoded build-time constants (mirroring the pattern used in
+// `src/services/api/base_url.js`); there is no `.env`/`import.meta.env` usage
+// in the frontend, so changing behavior means editing this file and rebuilding.
+
+export const APP_CONFIG = {
+    // Whether the territory map background should stick to (pan/zoom together
+    // with) the islands.
+    //
+    //   true  — the background lives inside the panzoom'd map, so when the
+    //           player drags the map the background moves with the islands.
+    //           This is the intended behavior: islands stay fixed relative to
+    //           the background instead of appearing to slide across a static
+    //           backdrop.
+    //   false — the background is rendered as a static, fixed backdrop while
+    //           the islands pan/zoom on top of it (legacy behavior).
+    STICK_BACKGROUND_TO_ISLANDS: true,
+};

--- a/frontend/src/pages/Territory.vue
+++ b/frontend/src/pages/Territory.vue
@@ -3,8 +3,6 @@
         class="w-full h-screen flex justify-center items-center p-4 box-border overflow-hidden relative"
     >
         <StarryNight v-if="!stickBackground" />
-        <!-- Solid backdrop kept in both modes so no area ever renders white,
-             e.g. corners the panned/zoomed map background doesn't reach. -->
         <div class="fixed inset-0 bg-[#0c2036] -z-20"></div>
         <div
             v-if="isLoading"

--- a/frontend/src/pages/Territory.vue
+++ b/frontend/src/pages/Territory.vue
@@ -2,7 +2,15 @@
     <div
         class="w-full h-screen flex justify-center items-center p-4 box-border overflow-hidden relative"
     >
-        <StarryNight v-if="!stickBackground" />
+        <StarryNight v-if="starryBackground" />
+        <div
+            v-if="fixedBackground && backgroundImage"
+            class="fixed inset-0 -z-10 bg-center bg-no-repeat"
+            :style="{
+                backgroundImage: `url(${backgroundImage})`,
+                backgroundSize: 'contain',
+            }"
+        ></div>
         <div class="fixed inset-0 bg-[#0c2036] -z-20"></div>
         <div
             v-if="isLoading"
@@ -68,7 +76,7 @@ import {
 import { usePlayerWebSocket } from '@/services/websocket.js';
 import { useInboxWebSocket } from '@/services/inboxWebsocket.js';
 import eventBus from '@/services/eventBus.js';
-import { APP_CONFIG } from '@/config/appConfig.js';
+import { APP_CONFIG, BACKGROUND_MODES } from '@/config/appConfig.js';
 
 import MapView from '@/components/features/map/MapView.vue';
 import IslandInfoBox from '@/components/features/map/IslandInfoBox.vue';
@@ -79,7 +87,9 @@ import StarryNight from '@/components/common/StarryNight.vue';
 import UserProfile from '@/components/layout/UserProfile.vue';
 import UnreadMessageIndicator from '@/components/features/notification/UnreadMessageIndicator.vue';
 
-const stickBackground = APP_CONFIG.STICK_BACKGROUND_TO_ISLANDS;
+const backgroundMode = APP_CONFIG.BACKGROUND_MODE;
+const fixedBackground = backgroundMode === BACKGROUND_MODES.FIXED;
+const starryBackground = backgroundMode === BACKGROUND_MODES.STARRY;
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/src/pages/Territory.vue
+++ b/frontend/src/pages/Territory.vue
@@ -2,7 +2,9 @@
     <div
         class="w-full h-screen flex justify-center items-center p-4 box-border overflow-hidden relative"
     >
-        <StarryNight />
+        <StarryNight v-if="!stickBackground" />
+        <!-- Solid backdrop kept in both modes so no area ever renders white,
+             e.g. corners the panned/zoomed map background doesn't reach. -->
         <div class="fixed inset-0 bg-[#0c2036] -z-20"></div>
         <div
             v-if="isLoading"
@@ -20,6 +22,7 @@
                 :username="username"
                 :dynamic-view-box="dynamicViewBox"
                 :territory-id="territoryId"
+                :background-image="backgroundImage"
                 @node-click="showInfoBox"
                 @map-transformed="updateInfoBoxPosition"
             />
@@ -67,6 +70,7 @@ import {
 import { usePlayerWebSocket } from '@/services/websocket.js';
 import { useInboxWebSocket } from '@/services/inboxWebsocket.js';
 import eventBus from '@/services/eventBus.js';
+import { APP_CONFIG } from '@/config/appConfig.js';
 
 import MapView from '@/components/features/map/MapView.vue';
 import IslandInfoBox from '@/components/features/map/IslandInfoBox.vue';
@@ -76,6 +80,8 @@ import Toolbar from '@/components/layout/Toolbar.vue';
 import StarryNight from '@/components/common/StarryNight.vue';
 import UserProfile from '@/components/layout/UserProfile.vue';
 import UnreadMessageIndicator from '@/components/features/notification/UnreadMessageIndicator.vue';
+
+const stickBackground = APP_CONFIG.STICK_BACKGROUND_TO_ISLANDS;
 
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
Add a STICK_BACKGROUND_TO_ISLANDS config flag (src/config/appConfig.js). When enabled (default), the territory background is rendered inside the panzoom'd map SVG so it pans and zooms together with the islands, instead of the islands appearing to slide across a static backdrop.

The background is sized (object-fit: contain) to show the whole image at minimum zoom, matched to the image's aspect ratio so it is never cropped, and constrainToBackground() clamps/recenters pan-zoom so the map always covers the viewport (blue backdrop only ever shows as thin padding). Setting the flag to false preserves the legacy static-starfield behavior.

Also skip the Bale bot GetMe call in DevMode (unreachable locally and otherwise fatal on boot) and fix mock territory background asset paths.