### PR TITLE
refactor(frontend): extract shared reconnecting-WebSocket factory

### DIFF
--- a/frontend/src/services/inboxWebsocket.js
+++ b/frontend/src/services/inboxWebsocket.js
@@ -3,15 +3,10 @@ import { getToken, getInboxMessages } from '@/services/api/index.js';
 import { API_ENDPOINTS } from '@/services/api/config.js';
 import { notificationService } from '@/services/notificationService.js';
 import { uiState } from '@/services/uiState.js';
+import { createReconnectingSocket } from '@/services/ws/reconnectingSocket.js';
 
 export const messages = ref([]);
 export const syncOffset = ref(null);
-
-let socket = null;
-let reconnectTimeoutId = null;
-let reconnectAttempts = 0;
-const maxReconnectAttempts = 10;
-const baseReconnectDelay = 1000;
 
 async function triggerNotificationCheck() {
     try {
@@ -29,79 +24,32 @@ async function triggerNotificationCheck() {
     }
 }
 
-function handleMessage(event) {
-    try {
-        const data = JSON.parse(event.data);
-        if (data.ok === false) {
-            console.error('[InboxWS] Received error event:', data.error);
-            return;
-        }
-        const eventData = data;
-        if (eventData.sync) {
-            syncOffset.value = eventData.sync.offset;
-            return;
-        }
-        const newMessage = eventData.newMessage || eventData;
-        if (newMessage.content && newMessage.createdAt) {
-            messages.value.unshift(newMessage);
-            triggerNotificationCheck();
-        }
-    } catch (error) {
-        console.error('[InboxWS] Error parsing message:', error);
+function handleMessage(data) {
+    if (data.ok === false) {
+        console.error('[InboxWS] Received error event:', data.error);
+        return;
+    }
+    if (data.sync) {
+        syncOffset.value = data.sync.offset;
+        return;
+    }
+    const newMessage = data.newMessage || data;
+    if (newMessage.content && newMessage.createdAt) {
+        messages.value.unshift(newMessage);
+        triggerNotificationCheck();
     }
 }
 
-export function useInboxWebSocket() {
-    const scheduleReconnect = () => {
-        if (reconnectAttempts >= maxReconnectAttempts) {
-            console.error(
-                '[InboxWS] Max reconnection attempts reached. Giving up.'
-            );
-            return;
-        }
-        const delay = Math.min(
-            baseReconnectDelay * Math.pow(2, reconnectAttempts),
-            30000
-        );
-        reconnectAttempts++;
-        reconnectTimeoutId = setTimeout(connect, delay);
-    };
-
-    const disconnect = () => {
-        if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
-        if (socket) {
-            socket.onclose = null;
-            socket.close(1000, 'Connection closed by client.');
-            socket = null;
-        }
-    };
-
-    const connect = () => {
-        if (socket && socket.readyState < 2) {
-            return;
-        }
+const { connect, disconnect } = createReconnectingSocket({
+    buildUrl: () => {
         const token = getToken();
-        if (!token) {
-            return;
-        }
+        return token ? `${API_ENDPOINTS.inboxEvents}?token=${token}` : null;
+    },
+    onMessage: handleMessage,
+    label: 'InboxWS',
+});
 
-        socket = new WebSocket(`${API_ENDPOINTS.inboxEvents}?token=${token}`);
-
-        socket.onopen = () => {
-            reconnectAttempts = 0;
-        };
-        socket.onmessage = handleMessage;
-        socket.onclose = event => {
-            socket = null;
-            if (event.code !== 1000) {
-                scheduleReconnect();
-            }
-        };
-        socket.onerror = error => {
-            console.error('[InboxWS] WebSocket error:', error);
-        };
-    };
-
+export function useInboxWebSocket() {
     onMounted(() => {
         connect();
     });

--- a/frontend/src/services/marketWebsocket.js
+++ b/frontend/src/services/marketWebsocket.js
@@ -1,6 +1,7 @@
 import { onMounted, onUnmounted } from 'vue';
 import { getToken } from '@/services/api/index.js';
 import { API_ENDPOINTS } from '@/services/api/config.js';
+import { createReconnectingSocket } from '@/services/ws/reconnectingSocket.js';
 
 export function useMarketWebSocket(
     mySyncTrade,
@@ -8,131 +9,57 @@ export function useMarketWebSocket(
     myOffers,
     otherOffers
 ) {
-    let socket = null;
-    let reconnectTimeoutId = null;
-    let reconnectAttempts = 0;
-    const maxReconnectAttempts = 10;
-    const baseReconnectDelay = 1000;
+    const handleMessage = data => {
+        console.log('Market WebSocket message received:', data);
 
-    const disconnect = () => {
-        if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
-
-        if (socket) {
-            socket.onclose = null;
-            socket.onmessage = null;
-            socket.onerror = null;
-            socket.onopen = null;
-            socket.close(1000, 'Connection closed intentionally by client');
-            socket = null;
-            console.log('Market WebSocket connection cleanly disconnected.');
+        if (data.sync) {
+            mySyncTrade.value = data.sync.offset;
+            otherSyncTrade.value = data.sync.offset;
         }
-    };
-
-    const connect = () => {
-        if (socket) return;
-
-        const token = getToken();
-        if (!token) {
-            console.error(
-                'Market WebSocket: No auth token found, connection aborted.'
-            );
-            return;
+        if (data.new_offer) {
+            if (data.new_offer.offer.byMe) {
+                myOffers.value.unshift(data.new_offer.offer);
+                mySyncTrade.value = data.new_offer.offer.created_at;
+            } else {
+                otherOffers.value.unshift(data.new_offer.offer);
+                otherSyncTrade.value = data.new_offer.offer.created_at;
+            }
         }
-
-        console.log('Attempting to connect Market WebSocket...');
-        socket = new WebSocket(`${API_ENDPOINTS.marketEvents}?token=${token}`);
-
-        socket.onopen = () => {
-            console.log('Market WebSocket connection established.');
-            reconnectAttempts = 0;
-        };
-
-        socket.onmessage = event => {
-            try {
-                const data = JSON.parse(event.data);
-                console.log('Market WebSocket message received:', data);
-
-                if (data.sync) {
-                    mySyncTrade.value = data.sync.offset;
-                    otherSyncTrade.value = data.sync.offset;
-                }
-                if (data.new_offer) {
-                    if (data.new_offer.offer.byMe) {
-                        myOffers.value.unshift(data.new_offer.offer);
-                        mySyncTrade.value = data.new_offer.offer.created_at;
-                    } else {
-                        otherOffers.value.unshift(data.new_offer.offer);
-                        otherSyncTrade.value = data.new_offer.offer.created_at;
+        if (data.deleted_offer) {
+            if (data.deleted_offer.byMe) {
+                for (let offer of myOffers.value) {
+                    if (offer.id == data.deleted_offer.offerID) {
+                        myOffers.value.splice(myOffers.value.indexOf(offer), 1);
+                        break;
                     }
                 }
-                if (data.deleted_offer) {
-                    if (data.deleted_offer.byMe) {
-                        for (let offer of myOffers.value) {
-                            if (offer.id == data.deleted_offer.offerID) {
-                                myOffers.value.splice(
-                                    myOffers.value.indexOf(offer),
-                                    1
-                                );
-                                break;
-                            }
-                        }
-                    } else {
-                        for (let offer of otherOffers.value) {
-                            if (offer.id == data.deleted_offer.offerID) {
-                                otherOffers.value.splice(
-                                    otherOffers.value.indexOf(offer),
-                                    1
-                                );
-                                break;
-                            }
-                        }
+            } else {
+                for (let offer of otherOffers.value) {
+                    if (offer.id == data.deleted_offer.offerID) {
+                        otherOffers.value.splice(
+                            otherOffers.value.indexOf(offer),
+                            1
+                        );
+                        break;
                     }
                 }
-            } catch (error) {
-                console.error('Error parsing Market WebSocket message:', error);
             }
-        };
-
-        socket.onclose = event => {
-            console.log(
-                'Market WebSocket connection closed. Code:',
-                event.code
-            );
-            socket = null;
-
-            if (event.code !== 1000) {
-                scheduleReconnect();
-            }
-        };
-
-        socket.onerror = error => {
-            console.error('Market WebSocket error:', error);
-        };
-    };
-
-    const scheduleReconnect = () => {
-        if (reconnectAttempts >= maxReconnectAttempts) {
-            console.error(
-                'Max Market WebSocket reconnection attempts reached. Giving up.'
-            );
-            return;
         }
-        const delay = Math.min(
-            baseReconnectDelay * Math.pow(2, reconnectAttempts),
-            30000
-        );
-        reconnectAttempts++;
-
-        console.log(
-            `Scheduling Market WebSocket reconnection attempt ${reconnectAttempts} in ${delay}ms`
-        );
-        reconnectTimeoutId = setTimeout(connect, delay);
     };
+
+    const { connect, disconnect } = createReconnectingSocket({
+        buildUrl: () => {
+            const token = getToken();
+            return token
+                ? `${API_ENDPOINTS.marketEvents}?token=${token}`
+                : null;
+        },
+        onMessage: handleMessage,
+        label: 'Market WebSocket',
+    });
 
     onMounted(() => {
-        if (!socket) {
-            connect();
-        }
+        connect();
     });
 
     onUnmounted(() => {

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -5,152 +5,77 @@ import emitter from '@/services/eventBus.js';
 import { notificationService } from '@/services/notificationService.js';
 import { uiState } from '@/services/uiState.js';
 import { messages as inboxMessages } from '@/services/inboxWebsocket.js';
+import { createReconnectingSocket } from '@/services/ws/reconnectingSocket.js';
 
 export function usePlayerWebSocket(player, territoryId, route, router) {
-    let socket = null;
-    let reconnectTimeoutId = null;
-    let reconnectAttempts = 0;
-    const maxReconnectAttempts = 10;
-    const baseReconnectDelay = 1000;
+    const handleMessage = async data => {
+        console.log('WebSocket message received:', data);
 
-    const disconnect = () => {
-        if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
+        if (!data.playerUpdate) return;
 
-        if (socket) {
-            socket.onclose = null;
-            socket.onmessage = null;
-            socket.onerror = null;
-            socket.onopen = null;
-            socket.close(1000, 'Connection closed intentionally by client');
-            socket = null;
-            console.log('WebSocket connection cleanly disconnected.');
-        }
-    };
-
-    const connect = () => {
-        if (socket) return;
-
-        const token = getToken();
-        if (!token) {
-            console.error(
-                'WebSocket: No auth token found, connection aborted.'
-            );
-            return;
-        }
-
-        console.log('Attempting to connect WebSocket...');
-        socket = new WebSocket(`${API_ENDPOINTS.events}?token=${token}`);
-
-        socket.onopen = () => {
-            console.log('WebSocket connection established.');
-            reconnectAttempts = 0;
-        };
-
-        socket.onmessage = async event => {
+        const reason = data.playerUpdate.reason;
+        if (reason === 'correction' || reason === 'ownOfferAccepted') {
             try {
-                const data = JSON.parse(event.data);
-                console.log('WebSocket message received:', data);
+                const result = await getInboxMessages(null, 20);
+                const allMessages = result?.messages || result || [];
 
-                if (data.playerUpdate) {
-                    const reason = data.playerUpdate.reason;
-                    if (
-                        reason === 'correction' ||
-                        reason === 'ownOfferAccepted'
-                    ) {
-                        try {
-                            const result = await getInboxMessages(null, 20);
-                            const allMessages =
-                                result?.messages || result || [];
+                inboxMessages.value = allMessages;
 
-                            inboxMessages.value = allMessages;
+                notificationService.setReceivedMessages(allMessages);
 
-                            notificationService.setReceivedMessages(
-                                allMessages
-                            );
-
-                            if (uiState.isInboxOpen) {
-                                notificationService.markAllAsSeen();
-                            }
-                        } catch (apiError) {
-                            console.error(
-                                'Failed to fetch inbox messages after playerUpdate event:',
-                                apiError
-                            );
-                        }
-                    }
-
-                    const oldPlayerState = JSON.parse(
-                        JSON.stringify(player.value)
-                    );
-                    const newPlayerState = data.playerUpdate.player;
-
-                    player.value = newPlayerState;
-
-                    if (reason === 'unlockTreasure') {
-                        emitter.emit('treasure-unlocked', {
-                            oldPlayerState,
-                            newPlayerState,
-                        });
-                    }
-
-                    if (
-                        router &&
-                        route &&
-                        territoryId &&
-                        territoryId.value &&
-                        newPlayerState.atTerritory != territoryId.value &&
-                        !route.params.islandId
-                    ) {
-                        router.push({
-                            name: 'Territory',
-                            params: { id: newPlayerState.atTerritory },
-                        });
-                    }
+                if (uiState.isInboxOpen) {
+                    notificationService.markAllAsSeen();
                 }
-            } catch (error) {
-                console.error('Error parsing WebSocket message:', error);
+            } catch (apiError) {
+                console.error(
+                    'Failed to fetch inbox messages after playerUpdate event:',
+                    apiError
+                );
             }
-        };
-
-        socket.onclose = event => {
-            console.log('WebSocket connection closed. Code:', event.code);
-            socket = null;
-
-            if (event.code !== 1000) {
-                scheduleReconnect();
-            }
-        };
-
-        socket.onerror = error => {
-            console.error('WebSocket error:', error);
-        };
-    };
-
-    const scheduleReconnect = () => {
-        if (reconnectAttempts >= maxReconnectAttempts) {
-            console.error(
-                'Max WebSocket reconnection attempts reached. Giving up.'
-            );
-            return;
         }
-        const delay = Math.min(
-            baseReconnectDelay * Math.pow(2, reconnectAttempts),
-            30000
-        );
-        reconnectAttempts++;
 
-        console.log(
-            `Scheduling WebSocket reconnection attempt ${reconnectAttempts} in ${delay}ms`
-        );
-        reconnectTimeoutId = setTimeout(connect, delay);
+        const oldPlayerState = JSON.parse(JSON.stringify(player.value));
+        const newPlayerState = data.playerUpdate.player;
+
+        player.value = newPlayerState;
+
+        if (reason === 'unlockTreasure') {
+            emitter.emit('treasure-unlocked', {
+                oldPlayerState,
+                newPlayerState,
+            });
+        }
+
+        if (
+            router &&
+            route &&
+            territoryId &&
+            territoryId.value &&
+            newPlayerState.atTerritory != territoryId.value &&
+            !route.params.islandId
+        ) {
+            router.push({
+                name: 'Territory',
+                params: { id: newPlayerState.atTerritory },
+            });
+        }
     };
+
+    const { connect, disconnect } = createReconnectingSocket({
+        buildUrl: () => {
+            const token = getToken();
+            return token ? `${API_ENDPOINTS.events}?token=${token}` : null;
+        },
+        onMessage: handleMessage,
+        label: 'WebSocket',
+    });
 
     watch(
         player,
         newPlayer => {
-            if (newPlayer && !socket) {
+            if (newPlayer) {
                 connect();
-            } else if (!newPlayer && socket) {
+            } else {
                 disconnect();
             }
         },

--- a/frontend/src/services/ws/reconnectingSocket.js
+++ b/frontend/src/services/ws/reconnectingSocket.js
@@ -1,0 +1,91 @@
+const MAX_RECONNECT_ATTEMPTS = 10;
+const BASE_RECONNECT_DELAY = 1000;
+const MAX_RECONNECT_DELAY = 30000;
+
+export function createReconnectingSocket({
+    buildUrl,
+    onOpen,
+    onMessage,
+    onError,
+    label = 'WebSocket',
+}) {
+    let socket = null;
+    let reconnectTimeoutId = null;
+    let reconnectAttempts = 0;
+
+    const disconnect = () => {
+        if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
+
+        if (socket) {
+            socket.onclose = null;
+            socket.onmessage = null;
+            socket.onerror = null;
+            socket.onopen = null;
+            socket.close(1000, 'Connection closed intentionally by client');
+            socket = null;
+            console.log(`${label} connection cleanly disconnected.`);
+        }
+    };
+
+    const scheduleReconnect = () => {
+        if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+            console.error(
+                `Max ${label} reconnection attempts reached. Giving up.`
+            );
+            return;
+        }
+        const delay = Math.min(
+            BASE_RECONNECT_DELAY * Math.pow(2, reconnectAttempts),
+            MAX_RECONNECT_DELAY
+        );
+        reconnectAttempts++;
+
+        console.log(
+            `Scheduling ${label} reconnection attempt ${reconnectAttempts} in ${delay}ms`
+        );
+        reconnectTimeoutId = setTimeout(connect, delay);
+    };
+
+    const connect = () => {
+        if (socket) return;
+
+        const url = buildUrl();
+        if (!url) {
+            console.error(`${label}: No auth token found, connection aborted.`);
+            return;
+        }
+
+        console.log(`Attempting to connect ${label}...`);
+        socket = new WebSocket(url);
+
+        socket.onopen = () => {
+            console.log(`${label} connection established.`);
+            reconnectAttempts = 0;
+            onOpen?.();
+        };
+
+        socket.onmessage = event => {
+            try {
+                onMessage(JSON.parse(event.data));
+            } catch (error) {
+                console.error(`Error parsing ${label} message:`, error);
+            }
+        };
+
+        socket.onclose = event => {
+            console.log(`${label} connection closed. Code:`, event.code);
+            socket = null;
+
+            if (event.code !== 1000) {
+                scheduleReconnect();
+            }
+        };
+
+        socket.onerror = error => {
+            console.error(`${label} error:`, error);
+            onError?.(error);
+        };
+    };
+
+    return { connect, disconnect };
+}


### PR DESCRIPTION
websocket.js, marketWebsocket.js, and inboxWebsocket.js each reimplemented the same connect/disconnect/exponential-backoff-reconnect logic almost verbatim. Extract createReconnectingSocket() into services/ws/ so each channel only supplies its URL builder and message handler; reconnect behavior (10 attempts, 1s base delay doubling up to 30s cap) is unchanged.