### PR TITLE
feat(backend): expose general settings admin API endpoints

### DIFF
--- a/backend/api/handler/admin.go
+++ b/backend/api/handler/admin.go
@@ -15,8 +15,11 @@ import (
 )
 
 type admin struct {
-	cfg          config.Config
-	adminService *service.Admin
+	cfg           config.Config
+	adminService  *service.Admin
+	playerService *service.Player
+	gameState     domain.GameStateStore
+	actives       func() map[string]int
 }
 
 type adminLoginRequest struct {
@@ -233,4 +236,56 @@ func (a *admin) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sendResult(w, result)
+}
+
+func (a *admin) GetGameState(w http.ResponseWriter, r *http.Request) {
+	isPaused, err := a.gameState.GetIsPaused(r.Context())
+	if err != nil {
+		a.handleAdminError(w, err)
+		return
+	}
+	sendResult(w, map[string]any{"isPaused": isPaused})
+}
+
+type setGameStateRequest struct {
+	IsPaused bool `json:"isPaused"`
+}
+
+func (a *admin) SetGameState(w http.ResponseWriter, r *http.Request) {
+	var req setGameStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendDecodeError(w)
+		return
+	}
+	if err := a.gameState.SetIsPaused(r.Context(), req.IsPaused); err != nil {
+		a.handleAdminError(w, err)
+		return
+	}
+	sendResult(w, map[string]any{"isPaused": req.IsPaused})
+}
+
+type broadcastRequest struct {
+	Message string `json:"message"`
+}
+
+func (a *admin) Broadcast(w http.ResponseWriter, r *http.Request) {
+	var req broadcastRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendDecodeError(w)
+		return
+	}
+	if strings.TrimSpace(req.Message) == "" {
+		sendError(w, http.StatusBadRequest, "message is required")
+		return
+	}
+	count, err := a.playerService.BroadcastMessage(r.Context(), req.Message)
+	if err != nil {
+		a.handleAdminError(w, err)
+		return
+	}
+	sendResult(w, map[string]any{"sentTo": count})
+}
+
+func (a *admin) GetConnections(w http.ResponseWriter, r *http.Request) {
+	sendResult(w, a.actives())
 }

--- a/backend/api/handler/handler.go
+++ b/backend/api/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/Rastaiha/bermudia/api/hub"
 	"github.com/Rastaiha/bermudia/internal/config"
+	"github.com/Rastaiha/bermudia/internal/domain"
 	"github.com/Rastaiha/bermudia/internal/service"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -31,12 +32,14 @@ type Handler struct {
 	inboxHub         *hub.Hub
 }
 
-func New(cfg config.Config, authService *service.Auth, adminService *service.Admin, territoryService *service.Territory, islandService *service.Island, playerService *service.Player) *Handler {
-	return &Handler{
+func New(cfg config.Config, authService *service.Auth, adminService *service.Admin, territoryService *service.Territory, islandService *service.Island, playerService *service.Player, gameState domain.GameStateStore) *Handler {
+	h := &Handler{
 		cfg: cfg,
 		adminHandler: &admin{
-			cfg:          cfg,
-			adminService: adminService,
+			cfg:           cfg,
+			adminService:  adminService,
+			playerService: playerService,
+			gameState:     gameState,
 		},
 		authService:      authService,
 		territoryService: territoryService,
@@ -46,6 +49,8 @@ func New(cfg config.Config, authService *service.Auth, adminService *service.Adm
 		tradeHub:         hub.NewHub(),
 		inboxHub:         hub.NewHub(),
 	}
+	h.adminHandler.actives = h.Actives
+	return h
 }
 
 func (h *Handler) Start() {
@@ -126,6 +131,10 @@ func (h *Handler) Start() {
 			r.Post("/pools/{poolID}/books", h.adminHandler.SetBookAndBindToPool)
 			r.Get("/users", h.adminHandler.GetUsers)
 			r.Post("/users", h.adminHandler.CreateUser)
+			r.Get("/game_state", h.adminHandler.GetGameState)
+			r.Post("/game_state", h.adminHandler.SetGameState)
+			r.Post("/broadcast", h.adminHandler.Broadcast)
+			r.Get("/connections", h.adminHandler.GetConnections)
 		})
 	})
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 	}
 
-	h := handler.New(cfg, authService, adminService, territoryService, islandService, playerService)
+	h := handler.New(cfg, authService, adminService, territoryService, islandService, playerService, gameStateRepo)
 
 	adminBot := adminbot.NewBot(cfg, theBot, h, islandService, correctionService, playerService, adminService, userRepo, gameStateRepo)
 


### PR DESCRIPTION
Add HTTP endpoints under /admin for game controls that previously existed only in the Telegram/Bale bot, in preparation for the web admin panel:

- GET  /admin/game_state   -> { isPaused }
- POST /admin/game_state   -> set pause/resume
- POST /admin/broadcast    -> broadcast a message, returns { sentTo }
- GET  /admin/connections  -> live hub counts (players/market/inbox)

Wires GameStateStore and the player service into the admin handler and passes gameStateRepo through handler.New. No schema changes; reuses the existing admin auth, GameStateStore, BroadcastMessage, and Actives logic.